### PR TITLE
Control DM header output via env var

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-    "rust-analyzer.cargo.target": "i686-pc-windows-msvc",
-    "rust-analyzer.linkedProjects": [
-        ".\\Cargo.toml"
-    ],
     "rust-analyzer.rustfmt.extraArgs": [
         "+nightly"
     ],

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 //! Buildscript which will save a `iconforge_rs.dm` with the DLL's public API.
 
-use std::{fs::File, io::Write};
+use std::{env, fs::File, io::Write, path::Path};
 
 macro_rules! feature_dm_file {
 	($name:expr) => {
@@ -9,7 +9,16 @@ macro_rules! feature_dm_file {
 }
 
 fn main() {
-	let mut f = File::create("target/iconforge_rs.dm").unwrap();
+	let target_dir = env::var("DM_OUT_DIR").unwrap_or_else(|_| String::from("target"));
+	if target_dir.trim().is_empty() {
+		return;
+	}
+	let dm_path = Path::new(&target_dir).join("iconforge_rs.dm");
+	let mut f = File::create(&dm_path).expect(&format!(
+		"Couldn't open `{}` for writing iconforge-rs DM headers. Set DM_OUT_DIR to an empty \
+		 string to disable writing headers or to an absolute path you want to write headers to.",
+		dm_path.display()
+	));
 
 	// header
 	writeln!(


### PR DESCRIPTION
Fixes #1 

Makes it easy to control where DM headers are written or to disable entirely via a `.cargo/config.toml` like this
```
[env]
DM_OUT_DIR = ""
```

also removed some windows-specific vscode settings (they crash on linux :( )